### PR TITLE
feat: 접근 불가능한 link인 경우 제어

### DIFF
--- a/src/contents/contents.service.ts
+++ b/src/contents/contents.service.ts
@@ -37,7 +37,7 @@ export class ContentsService {
 
       // get og tag info from link
       let coverImg: string = '';
-      const axiosResult: AddContentOutput = await axios
+      await axios
         .get(link)
         .then((res) => {
           if (res.status !== 200) {
@@ -58,16 +58,13 @@ export class ContentsService {
                 }
               });
             }
-            return { ok: true };
           }
         })
         .catch((e) => {
-          return { ok: false, error: e.message };
+          console.log(e.message);
+          // Control unreachable link
+          title = link.split('/').at(-1);
         });
-
-      if (!axiosResult.ok) {
-        return axiosResult;
-      }
 
       // Get or create category
       const category = categoryName


### PR DESCRIPTION
자격 증명이 필요한 이유 등으로 접근이 불가하여
"Maximum number of redirects exceeded"와 같은
에러가 발생할 경우 link를 저장하지 못하도록 처리했었으나

Pocket을 벤치마킹하여 uri의 마지막 path를 title로 처리하여
저장하도록 구현함