### PR TITLE
docs: swagger api docs - User Entity의 password property 수정

### DIFF
--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -33,7 +33,11 @@ export class User extends CoreEntity {
   @IsEmail()
   email: string;
 
-  @ApiProperty({ example: 'p@ssw0rd', description: 'User Password' })
+  @ApiProperty({
+    example: 'p@ssw0rd',
+    description: 'User Password',
+    required: false,
+  })
   @Column({ select: false })
   @IsString()
   password: string;


### PR DESCRIPTION
password는 db query 시 불러와지지 않도록 했으므로
required 옵션을 false로 설정