### PR TITLE
improve: swagger api doc를 위한 property 추가

### DIFF
--- a/src/common/dtos/output.dto.ts
+++ b/src/common/dtos/output.dto.ts
@@ -2,6 +2,12 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean } from 'class-validator';
 
 export class CoreOutput {
+  @ApiProperty({
+    description: 'Status Code',
+    example: 200,
+  })
+  statusCode?: number;
+
   @ApiProperty({ description: '에러 메시지', required: false })
   error?: string;
 }

--- a/src/common/interceptors/success.interceptor.ts
+++ b/src/common/interceptors/success.interceptor.ts
@@ -4,6 +4,7 @@ import {
   ExecutionContext,
   CallHandler,
 } from '@nestjs/common';
+import { ApiProperty } from '@nestjs/swagger';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -15,7 +16,10 @@ export class SuccessInterceptor implements NestInterceptor {
         const statusCode: number = context
           .switchToHttp()
           .getResponse().statusCode;
-        return { statusCode: statusCode, ...returnValue };
+        return {
+          statusCode: statusCode,
+          ...returnValue,
+        };
       }),
     );
   }


### PR DESCRIPTION
CoreOutput에 statusCode property를 추가하여
api 문서로 확인했을 때 interceptor 및 filter를 통해
완성되는 response 구조를 알 수 있도록 함